### PR TITLE
Fix the domain

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ title: marcoshplace
 description: > # this means to ignore newlines until "baseurl:"
   A place to store my thoughts and ideas about programming and related stuff
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "http://marcosh.github.com" # the base hostname & protocol for your site
+url: "http://marcosh.github.io" # the base hostname & protocol for your site
 twitter_username: marcoshuttle
 github_username: marcosh
 


### PR DESCRIPTION
GitHub pages don't work on github.com – they're moved to github.io.
https://marcosh.github.com/post/2021/06/04/introducing-haskell-in-soisy.html is 404
https://marcosh.github.io/post/2021/06/04/introducing-haskell-in-soisy.html is 200